### PR TITLE
Fix benchmark processing log formatting

### DIFF
--- a/src/process_benchmark.py
+++ b/src/process_benchmark.py
@@ -52,7 +52,7 @@ def get_benchmarks() -> str:
 def analyze_benchmark(benchmark_dir: str):
     csv_file = Path(benchmark_dir) / "benchmark_results.csv"
 
-    print(f"nLese Daten aus {csv_file}")
+    print(f"\nLese Daten aus {csv_file}")
     df = pd.read_csv(csv_file)
 
     unique_k_vals = sorted(df['k'].unique())


### PR DESCRIPTION
## Summary
- Ensure benchmark data loading message prints on a new line in `process_benchmark.py` for clearer CLI output

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6899eaba897883209ad0b37ed15392ff