### PR TITLE
Add ReAct agent with self-consistency

### DIFF
--- a/examples/react_cot_sc_minimal/docs/sample.txt
+++ b/examples/react_cot_sc_minimal/docs/sample.txt
@@ -1,0 +1,2 @@
+Dies ist ein Beispieldokument, das im Minimalsetup verwendet wird.
+Es enthält einige Informationen über Sicherheitsrichtlinien.

--- a/examples/react_cot_sc_minimal/main.py
+++ b/examples/react_cot_sc_minimal/main.py
@@ -1,0 +1,9 @@
+from react_cot_sc import ReActCoTSCAgent
+
+def main() -> None:
+    agent = ReActCoTSCAgent(model="llama3", embedding_model_name="demo", k=2)
+    query = input("Frage: ")
+    print(agent.run(query))
+
+if __name__ == "__main__":
+    main()

--- a/examples/react_cot_sc_minimal/react_cot_sc.py
+++ b/examples/react_cot_sc_minimal/react_cot_sc.py
@@ -1,0 +1,141 @@
+"""ReAct-CoT-SC agent implementation.
+
+This module provides an example implementation of the
+Reason + Act (ReAct) paradigm enhanced with Chain of Thought (CoT)
+reasoning and a simple self-consistency check (SC).
+
+The agent accepts a user query and lets a reasoning model decide
+which action to take:
+
+* ``similarity_search`` – run a semantic search over indexed chunks
+  and use the retrieved passages as context.
+* ``retrieve_file`` – load whole documents and use them as context.
+
+After executing the chosen action, the agent verifies via another
+reasoning step whether the gathered context is sufficient to answer
+the question.  If it is, a final answer is generated.  If not, the
+agent performs a second iteration with a newly reasoned action.
+
+The code is intentionally lightweight and serves as a blueprint for
+integrating ReAct with CoT and a basic self‑consistency loop.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from langchain_ollama import ChatOllama, OllamaLLM
+from langchain_core.messages import HumanMessage
+
+from vector_db import get_vector_store, do_a_sim_search
+from utils import PROMPT_TEMPLATE, list_docx_files, build_compare_context
+
+
+@dataclass
+class ReActDecision:
+    """Represents a decision made by the reasoning model."""
+
+    action: str
+    query: str
+
+
+class ReActCoTSCAgent:
+    """Minimal ReAct agent with Chain of Thought and self‑consistency."""
+
+    def __init__(self, model: str, embedding_model_name: str, k: int = 5) -> None:
+        self.model = model
+        self.embedding_model_name = embedding_model_name
+        self.k = k
+        # Reasoning model is also used for final answer generation
+        self.reasoner = ChatOllama(model=model, temperature=0)
+        self.vector_store = get_vector_store(
+            embedding_model_name=embedding_model_name, persist=True
+        )
+
+    # ------------------------------------------------------------------
+    # Reasoning helpers
+    # ------------------------------------------------------------------
+    def _think(self, prompt: str) -> str:
+        """Run the reasoning model with a CoT style instruction."""
+        cot_prompt = (
+            "Denke Schritt für Schritt über das Problem nach und begründe deine Antwort.\n"
+            + prompt
+        )
+        msg = self.reasoner.invoke([HumanMessage(content=cot_prompt)])
+        return msg.content if hasattr(msg, "content") else str(msg)
+
+    def _decide_action(self, query: str) -> ReActDecision:
+        """Let the model choose an action and optionally reformulate the query."""
+        prompt = (
+            "Du kannst zwei Aktionen ausführen: "
+            "'similarity_search' für semantische Suche oder 'retrieve_file' zum Laden ganzer Dokumente.\n"
+            "Gib deine Entscheidung im Format:\n"
+            "ACTION: <similarity_search|retrieve_file>\n"
+            "QUERY: <formulierte Suchanfrage oder leer>"
+        )
+        response = self._think(f"{prompt}\nBenutzeranfrage: {query}")
+        action_line = next(
+            (l for l in response.splitlines() if l.lower().startswith("action:")),
+            "ACTION: similarity_search",
+        )
+        query_line = next(
+            (l for l in response.splitlines() if l.lower().startswith("query:")),
+            f"QUERY: {query}",
+        )
+        action = "retrieve_file" if "retrieve_file" in action_line.lower() else "similarity_search"
+        reformulated = query_line.split(":", 1)[1].strip()
+        return ReActDecision(action=action, query=reformulated or query)
+
+    def _is_context_sufficient(self, query: str, context: str) -> bool:
+        """Check via reasoning model if the context answers the question."""
+        prompt = (
+            f"Frage: {query}\n\nKontext:\n{context[:1000]}\n\n"  # limit to keep prompt short
+            "Reicht der Kontext aus, um die Frage zu beantworten? Antworte nur mit ja oder nein."
+        )
+        answer = self._think(prompt).strip().lower()
+        return answer.startswith("ja")
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+    def _run_similarity_search(self, query: str) -> str:
+        """Return a context string built from a semantic similarity search."""
+        results = do_a_sim_search(query, k=self.k, vector_store=self.vector_store)
+        parts = [f"[{i}] {doc.page_content}" for i, doc in enumerate(results, start=1)]
+        return "\n\n--- DOC SEP ---\n\n".join(parts)
+
+    def _retrieve_files(self, documents: Optional[List[str]] = None) -> str:
+        """Load full documents and return a combined context string."""
+        available = list_docx_files()
+        if documents:
+            docs = [d for d in available if d.name in documents]
+        else:
+            docs = available
+        context, _ = build_compare_context(docs, self.embedding_model_name)
+        return context
+
+    def _generate_final_answer(self, query: str, context: str) -> str:
+        """Generate the final answer conditioned on the context."""
+        llm = OllamaLLM(model=self.model, num_ctx=16384)
+        prompt = PROMPT_TEMPLATE.format(context=context, query=query)
+        result = llm.invoke(prompt)
+        return result.content if hasattr(result, "content") else str(result)
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+    def run(self, query: str) -> str:
+        """Execute the ReAct‑CoT‑SC loop for a user query."""
+        # We allow up to two iterations
+        context = ""
+        for _ in range(2):
+            decision = self._decide_action(query)
+            if decision.action == "similarity_search":
+                context = self._run_similarity_search(decision.query)
+            else:
+                context = self._retrieve_files()
+            if self._is_context_sufficient(query, context):
+                break
+        if not context:
+            return "[INFO] Es konnte kein Kontext erstellt werden."
+        return self._generate_final_answer(query, context)

--- a/examples/react_cot_sc_minimal/utils.py
+++ b/examples/react_cot_sc_minimal/utils.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from typing import List, Tuple
+
+PROMPT_TEMPLATE = """{context}\n\nFrage:\n{query}\n\nAntwort:"""
+
+def list_docx_files() -> List[Path]:
+    """Return demo documents shipped with the minimal example."""
+    data_dir = Path(__file__).parent / "docs"
+    return sorted(data_dir.glob("*.txt"))
+
+def build_compare_context(selected_docx: List[Path], embedding_model_name: str) -> Tuple[str, List[Tuple[int, str]]]:
+    """Create a numbered context string from the provided documents."""
+    parts = []
+    sources: List[Tuple[int, str]] = []
+    for i, path in enumerate(selected_docx, start=1):
+        text = path.read_text(encoding="utf-8")
+        parts.append(f"[{i}] {text}")
+        sources.append((i, path.name))
+    return "\n\n--- DOC SEP ---\n\n".join(parts), sources

--- a/examples/react_cot_sc_minimal/vector_db.py
+++ b/examples/react_cot_sc_minimal/vector_db.py
@@ -1,0 +1,22 @@
+from langchain_core.documents import Document
+from typing import List
+
+class InMemoryVectorStore:
+    """Very small in-memory store used for the minimal ReAct example."""
+    def __init__(self, docs: List[Document]):
+        self.docs = docs
+
+    def similarity_search(self, query: str, k: int = 5):
+        return self.docs[:k]
+
+def get_vector_store(embedding_model_name: str, persist: bool = True):
+    """Return an in-memory vector store populated with demo documents."""
+    docs = [
+        Document(page_content="Das ist ein Beispieldokument über Informationssicherheit."),
+        Document(page_content="Ein weiteres Dokument erklärt Business Continuity."),
+    ]
+    return InMemoryVectorStore(docs)
+
+def do_a_sim_search(query: str, k: int, vector_store: InMemoryVectorStore):
+    """Run a naive similarity search over the in-memory documents."""
+    return vector_store.similarity_search(query, k=k)

--- a/src/react_cot_sc.py
+++ b/src/react_cot_sc.py
@@ -1,0 +1,141 @@
+"""ReAct-CoT-SC agent implementation.
+
+This module provides an example implementation of the
+Reason + Act (ReAct) paradigm enhanced with Chain of Thought (CoT)
+reasoning and a simple self-consistency check (SC).
+
+The agent accepts a user query and lets a reasoning model decide
+which action to take:
+
+* ``similarity_search`` – run a semantic search over indexed chunks
+  and use the retrieved passages as context.
+* ``retrieve_file`` – load whole documents and use them as context.
+
+After executing the chosen action, the agent verifies via another
+reasoning step whether the gathered context is sufficient to answer
+the question.  If it is, a final answer is generated.  If not, the
+agent performs a second iteration with a newly reasoned action.
+
+The code is intentionally lightweight and serves as a blueprint for
+integrating ReAct with CoT and a basic self‑consistency loop.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from langchain_ollama import ChatOllama, OllamaLLM
+from langchain_core.messages import HumanMessage
+
+from vector_db import get_vector_store, do_a_sim_search
+from utils import PROMPT_TEMPLATE, list_docx_files, build_compare_context
+
+
+@dataclass
+class ReActDecision:
+    """Represents a decision made by the reasoning model."""
+
+    action: str
+    query: str
+
+
+class ReActCoTSCAgent:
+    """Minimal ReAct agent with Chain of Thought and self‑consistency."""
+
+    def __init__(self, model: str, embedding_model_name: str, k: int = 5) -> None:
+        self.model = model
+        self.embedding_model_name = embedding_model_name
+        self.k = k
+        # Reasoning model is also used for final answer generation
+        self.reasoner = ChatOllama(model=model, temperature=0)
+        self.vector_store = get_vector_store(
+            embedding_model_name=embedding_model_name, persist=True
+        )
+
+    # ------------------------------------------------------------------
+    # Reasoning helpers
+    # ------------------------------------------------------------------
+    def _think(self, prompt: str) -> str:
+        """Run the reasoning model with a CoT style instruction."""
+        cot_prompt = (
+            "Denke Schritt für Schritt über das Problem nach und begründe deine Antwort.\n"
+            + prompt
+        )
+        msg = self.reasoner.invoke([HumanMessage(content=cot_prompt)])
+        return msg.content if hasattr(msg, "content") else str(msg)
+
+    def _decide_action(self, query: str) -> ReActDecision:
+        """Let the model choose an action and optionally reformulate the query."""
+        prompt = (
+            "Du kannst zwei Aktionen ausführen: "
+            "'similarity_search' für semantische Suche oder 'retrieve_file' zum Laden ganzer Dokumente.\n"
+            "Gib deine Entscheidung im Format:\n"
+            "ACTION: <similarity_search|retrieve_file>\n"
+            "QUERY: <formulierte Suchanfrage oder leer>"
+        )
+        response = self._think(f"{prompt}\nBenutzeranfrage: {query}")
+        action_line = next(
+            (l for l in response.splitlines() if l.lower().startswith("action:")),
+            "ACTION: similarity_search",
+        )
+        query_line = next(
+            (l for l in response.splitlines() if l.lower().startswith("query:")),
+            f"QUERY: {query}",
+        )
+        action = "retrieve_file" if "retrieve_file" in action_line.lower() else "similarity_search"
+        reformulated = query_line.split(":", 1)[1].strip()
+        return ReActDecision(action=action, query=reformulated or query)
+
+    def _is_context_sufficient(self, query: str, context: str) -> bool:
+        """Check via reasoning model if the context answers the question."""
+        prompt = (
+            f"Frage: {query}\n\nKontext:\n{context[:1000]}\n\n"  # limit to keep prompt short
+            "Reicht der Kontext aus, um die Frage zu beantworten? Antworte nur mit ja oder nein."
+        )
+        answer = self._think(prompt).strip().lower()
+        return answer.startswith("ja")
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+    def _run_similarity_search(self, query: str) -> str:
+        """Return a context string built from a semantic similarity search."""
+        results = do_a_sim_search(query, k=self.k, vector_store=self.vector_store)
+        parts = [f"[{i}] {doc.page_content}" for i, doc in enumerate(results, start=1)]
+        return "\n\n--- DOC SEP ---\n\n".join(parts)
+
+    def _retrieve_files(self, documents: Optional[List[str]] = None) -> str:
+        """Load full documents and return a combined context string."""
+        available = list_docx_files()
+        if documents:
+            docs = [d for d in available if d.name in documents]
+        else:
+            docs = available
+        context, _ = build_compare_context(docs, self.embedding_model_name)
+        return context
+
+    def _generate_final_answer(self, query: str, context: str) -> str:
+        """Generate the final answer conditioned on the context."""
+        llm = OllamaLLM(model=self.model, num_ctx=16384)
+        prompt = PROMPT_TEMPLATE.format(context=context, query=query)
+        result = llm.invoke(prompt)
+        return result.content if hasattr(result, "content") else str(result)
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+    def run(self, query: str) -> str:
+        """Execute the ReAct‑CoT‑SC loop for a user query."""
+        # We allow up to two iterations
+        context = ""
+        for _ in range(2):
+            decision = self._decide_action(query)
+            if decision.action == "similarity_search":
+                context = self._run_similarity_search(decision.query)
+            else:
+                context = self._retrieve_files()
+            if self._is_context_sufficient(query, context):
+                break
+        if not context:
+            return "[INFO] Es konnte kein Kontext erstellt werden."
+        return self._generate_final_answer(query, context)


### PR DESCRIPTION
## Summary
- implement `ReActCoTSCAgent` that reasons between similarity search and file retrieval
- support chain-of-thought prompts and self-consistency check before answering
- provide a standalone minimal example including vector store, utils, and demo docs for separate testing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b3458970c8320ba1f1b31b7eab702